### PR TITLE
Added drag-end handling for drag-and-drop challenge

### DIFF
--- a/native/machine-coding/drag-and-drop-puzzle/index.js
+++ b/native/machine-coding/drag-and-drop-puzzle/index.js
@@ -30,8 +30,16 @@ function handleDrop(event) {
   draggingPiece = null;
 }
 
+// to handle when piece dropped outside dropzone
+function handleDragEnd(event){
+   // Reset the draggingPiece variable and remove the dragging class
+    draggingPiece?.classList?.remove('dragging');
+    draggingPiece = null;
+}
+
 pieces.forEach((piece) => {
   piece.addEventListener('dragstart', handleDragStart);
   piece.addEventListener('dragover', handleDragOver);
   piece.addEventListener('drop', handleDrop);
+  piece.addEventListener('dragend', handleDragEnd);
 });


### PR DESCRIPTION
### Issue
Whenever any image is dragged and dropped outside of the drop zone it still had `dragging` class attached to it.

### Solution
handled this case by adding `drag-end` event listener which removes the class `dragging` and resetting `draggingPiece` to null. 


