### PR TITLE
Update appended dist/angular base href

### DIFF
--- a/angular/package.json
+++ b/angular/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build-prod": "ng build --c=production --base-href=/frontend-mini-challenges/angular && npm run copy-index",
+    "build-prod": "ng build --c=production --base-href=/frontend-mini-challenges/angular/dist/angular && npm run copy-index",
     "copy-index": "cp dist/angular/index.html dist/angular/404.html",
     "watch": "ng build --watch --configuration development",
     "test": "ng test"

--- a/angular/src/main.ts
+++ b/angular/src/main.ts
@@ -9,7 +9,7 @@ bootstrapApplication(AppComponent, {
     provideRouter(routes),
     {
       provide: APP_BASE_HREF,
-      useValue: '/frontend-mini-challenges/angular/'
+      useValue: '/frontend-mini-challenges/angular/dist/angular/'
     }
   ]
 }).catch(err => console.error(err));


### PR DESCRIPTION
With previous deployment https://sadanandpai.github.io/frontend-mini-challenges/angular URL shows a readme.md page. Bringing back the `dist/angular` route at the end of the URL