### PR TITLE
[React]: Add avatar group for challenge cards

### DIFF
--- a/react/src/components/challenges/Avatar.tsx
+++ b/react/src/components/challenges/Avatar.tsx
@@ -1,0 +1,34 @@
+import { contributors } from '@/helpers/contributors'
+import styles from './avatar.module.css'
+
+interface AvatarProps {
+  src: string
+  alt: string
+}
+
+interface AvatarGroupProps {
+  contributorNames: string[]
+}
+
+export function Avatar({ src, alt }: AvatarProps) {
+  return (
+    <img src={src} alt={alt} className={styles.avatar} />
+  )
+}
+
+export function AvatarGroup({ contributorNames }: AvatarGroupProps) {
+  return (
+    <div className={styles.avatarGroup}>
+      {
+        contributorNames
+          .map(name => {
+            const src = contributors.get(name)?.pic
+
+            // If src is undefined, return null
+            return src ? <Avatar key={name} src={src} alt="" /> : null
+          })
+          .filter(Boolean) // Remove null values
+      }
+    </div>
+  )
+}

--- a/react/src/components/challenges/ChallengeGrid.tsx
+++ b/react/src/components/challenges/ChallengeGrid.tsx
@@ -1,5 +1,6 @@
 import { challenges } from '@/helpers/challenges';
 import { contributors } from '@/helpers/contributors';
+import { AvatarGroup } from './Avatar';
 import styles from './challenge-grid.module.scss';
 
 function ChallengeGrid() {
@@ -14,12 +15,18 @@ function ChallengeGrid() {
           {challenge.isNew && <span className={styles.new}>New</span>}
           <div>
             <h3>{challenge.title}</h3>
-            {challenge.developer && (
-              <div className={styles.developer}>
-                <img src={contributors.get(challenge.developer)?.pic} alt="" />
-                <span className={styles.name}>{contributors.get(challenge.developer)?.name}</span>
-              </div>
-            )}
+
+            <div className={styles.avatarContainer}>
+              {challenge.developer && (
+                <div className={styles.developer}>
+                  <img src={contributors.get(challenge.developer)?.pic} alt="" />
+                  <span className={styles.name}>{contributors.get(challenge.developer)?.name}</span>
+                </div>
+              )}
+              {challenge.contributors && (
+                <AvatarGroup contributorNames={challenge.contributors} />
+              )}
+            </div>
           </div>
         </a>
       ))}

--- a/react/src/components/challenges/avatar.module.css
+++ b/react/src/components/challenges/avatar.module.css
@@ -1,0 +1,19 @@
+.avatar {
+  display: inline-block;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 1000px;
+
+  /* Use shadow instead of border so that it does not occupy space */
+  box-shadow: 0 0 0 2px black;
+}
+
+.avatarGroup {
+  display: flex;
+  margin: auto;
+  width: max-content;
+}
+
+.avatarGroup > *:not(:first-child) {
+  margin-left: -0.3rem;
+}

--- a/react/src/components/challenges/challenge-grid.module.scss
+++ b/react/src/components/challenges/challenge-grid.module.scss
@@ -19,6 +19,10 @@
     transform: scale(1.05);
   }
 
+  .avatarContainer > *:not(:first-child) {
+    margin-top: 0.5rem;
+  }
+
   h3 {
     font-size: 1.25rem;
     font-weight: 500;
@@ -60,13 +64,13 @@
     justify-content: center;
     font-size: 0.8rem;
     color: black;
-  }
 
-  img {
-    width: 25px;
-    height: 25px;
-    margin-right: 0.5rem;
-    border-radius: 50%;
+    & > img {
+      width: 25px;
+      height: 25px;
+      margin-right: 0.5rem;
+      border-radius: 50%;
+    }
   }
 
   .name {

--- a/react/src/helpers/challenges.ts
+++ b/react/src/helpers/challenges.ts
@@ -1,4 +1,14 @@
-export const challenges = new Map([
+interface Challenge {
+  title: string
+  link: string
+  difficulty: string
+  developer?: string
+  contributors?: string[]
+  tags?: string[]
+  isNew?: boolean
+}
+
+export const challenges = new Map<string, Challenge>([
   [
     'counter',
     {

--- a/react/src/helpers/contributors.ts
+++ b/react/src/helpers/contributors.ts
@@ -1,4 +1,9 @@
-export const contributors = new Map([
+interface Contributor {
+  name: string
+  pic: string
+}
+
+export const contributors = new Map<string, Contributor>([
   ['sadanandpai', { name: 'Sadanand Pai', pic: 'https://avatars.githubusercontent.com/u/12962887' }],
   ['NikhilJHA01', { name: 'Nikhil Jha', pic: 'https://avatars.githubusercontent.com/u/63518046' }],
   ['noorulaink00', { name: 'Noor Ul Ain Khan', pic: 'https://avatars.githubusercontent.com/u/65324193' }],


### PR DESCRIPTION
If there are multiple contributors in a single challenge, then this avatar group may be used.

This is a demo example

![image](https://github.com/sadanandpai/frontend-mini-challenges/assets/82361490/d3fc7417-bb27-4e10-9374-22450bc6de7b)

I have not used it in the cards yet. Just added this AvatarGroup component in this PR.