### PR TITLE
[feat] Added error handling when rate limit is breached

### DIFF
--- a/react/src/machine-coding/autocomplete-offline/autocomplete.module.scss
+++ b/react/src/machine-coding/autocomplete-offline/autocomplete.module.scss
@@ -9,6 +9,16 @@
     margin-bottom: 0.5rem;
     font-size: 1rem;
   }
+  input:disabled {
+    background-color: rgba(0, 0, 0, 0.2);
+  }
+
+  .retryTimer {
+    margin: 7px;
+    font-size: 24px;
+    font-weight: 600;
+    color: #f14f4f;
+  }
 
   .suggestions {
     width: 93%;

--- a/react/src/machine-coding/autocomplete-offline/autocompleteOnline.tsx
+++ b/react/src/machine-coding/autocomplete-offline/autocompleteOnline.tsx
@@ -9,6 +9,7 @@ function AutocompleteOnline() {
     isLoading,
     suggestionFocus,
     errorMessage,
+    retryAfter,
     handleInputChange,
     handleSuggestionClick,
     handleKeyDown,
@@ -29,9 +30,11 @@ function AutocompleteOnline() {
         value={userText}
         onKeyDown={handleKeyDown}
         onChange={handleInputChange}
+        disabled={retryAfter !== 0}
       />
       {isLoading && <div id="loader" className={styles.loader}></div>}
       {errorMessage && <div id="info">{errorMessage}</div>}
+      {retryAfter !== 0 && <div className={styles.retryTimer}>{retryAfter}</div>}
       <ul className={styles.suggestions}>
         {suggestions.map((suggestion, index) => (
           <li

--- a/react/src/machine-coding/autocomplete-offline/hooks/useAutocompleteOnline.ts
+++ b/react/src/machine-coding/autocomplete-offline/hooks/useAutocompleteOnline.ts
@@ -13,15 +13,44 @@ interface AutocompleteResult {
 }
 const suggestionLength = 5;
 
-async function makeAPIRequest(text: string): Promise<string[]> {
+// The function to make API calls
+interface MakeApiRequestReturnType {
+  items: string[],
+  errorMsgFromApi: string
+  timeDelta: number
+}
+
+async function makeAPIRequest(text: string): Promise<MakeApiRequestReturnType> {
+  const result = {items: [], errorMsgFromApi: "", timeDelta: 0}
+
   try {
     const response = await fetch(
       `https://api.github.com/search/users?per_page=${suggestionLength}&q=${text}`
     );
-    const data = await response.json();
-    return data.items.map((item: AutocompleteResult) => item.login);
+
+    // The GitHub API responds with http 403 Forbidden when the rate limit is exceeded.
+    //
+    if (response.status === 403) {
+      // The API suspends further requests until a specified time. This specified time is included in the
+      // response header under the key "x-ratelimit-reset"
+      // https://docs.github.com/en/rest/guides/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#handle-rate-limit-errors-appropriately
+      const timeOfLimitReset = parseFloat(response.headers.get('x-ratelimit-reset'))
+
+      // Following line of code will calculate the number of seconds between the time at which the rate-limit was
+      // breached and the time at which we can start making requests again.
+      result.timeDelta = Math.ceil(timeOfLimitReset - (new Date() / 1000))
+      result.errorMsgFromApi = "Too many requests. Please wait before trying again."
+    } else {
+      const data = await response.json();
+      result.items = data.items.map((item:AutocompleteResult) => item.login)
+    }
+
+    return result
+
   } catch (e) {
-    return [];
+    result.errorMsgFromApi = "Error occurred while fetching suggestions"
+
+    return result;
   }
 }
 
@@ -31,6 +60,7 @@ export function useAutocompleteOnline() {
   const [suggestionFocus, setSuggestionFocus] = useState<number | null>(null);
 
   const [isLoading, setIsLoading] = useState(false);
+  const [retryAfter, setRetryAfter] = useState(0)
 
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -39,12 +69,19 @@ export function useAutocompleteOnline() {
       setIsLoading(true);
       try {
         const result = await makeAPIRequest(text);
-        if (result.length > 0) {
-          setSuggestions(result);
-          setErrorMessage("");
+
+        setRetryAfter(result.timeDelta)
+        if (!result.errorMsgFromApi) {
+          if (result.items.length > 0) {
+            setSuggestions(result.items)
+            setErrorMessage("")
+          } else {
+            setSuggestions([])
+            setErrorMessage("No results found")
+          }
         } else {
-          setSuggestions([]);
-          setErrorMessage("No results found");
+          setSuggestions([])
+          setErrorMessage(result.errorMsgFromApi)
         }
       } catch (error) {
         setSuggestions([]);
@@ -111,6 +148,17 @@ export function useAutocompleteOnline() {
     }
   }, [suggestionFocus, suggestions]);
 
+  // Start a countdown to zero as soon as the value of retryAfter changes
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      if (retryAfter > 0) {
+        setRetryAfter((prevVal) => prevVal - 1)
+      }
+    }, 1000)
+
+    return () => clearTimeout(timer)
+  }, [retryAfter])
+
   const handleSuggestionFocus = (index: number | null) => {
     setSuggestionFocus(index);
   };
@@ -121,6 +169,7 @@ export function useAutocompleteOnline() {
     isLoading,
     suggestionFocus,
     errorMessage,
+    retryAfter,
     handleInputChange,
     handleSuggestionClick,
     handleKeyDown,


### PR DESCRIPTION
# Error handling. Issue #330 
### Title : Handled API response 403. Added visual elements with better information for the user.

#### Description: 
Added a countdown timer when the API limit is breached. The timer counts down till when the rate-limit will reset and the user can start making requests again. Time is calculated from the response header "x-ratelimit-reset" which is received when the API limit is breached along with http status code 403.

#### Further Context:
 The API responds with a 403 Forbidden because beyond 10 requests per minute (which is the rate-limit for unauthenticated requests), it expects the requests to be authenticated. The ideal way to handle this would be to make the user login into GitHub before they can start searching, but this solution seems repelling for someone who is just on the website to check out "mini" challenges. In that case, the committed solution seems best to me.

Video of the implemented solution:
https://github.com/sadanandpai/frontend-mini-challenges/assets/67118535/202e6bd7-f0ca-4838-9fa2-96b89546515b

Issue No. : #330

Code Stack : React

Close #330 

# Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have created a helpful and easy to understand `README.md`
- [X] I have updated the Index.html file for my contribution