### PR TITLE
feat: placed only one CTA on home page

### DIFF
--- a/apps/host/src/components/modules/home/hero/hero.module.scss
+++ b/apps/host/src/components/modules/home/hero/hero.module.scss
@@ -19,21 +19,31 @@
 
   .heroImage {
     width: min(80vh, 80vw);
-    aspect-ratio: calc(1120/736);
+    aspect-ratio: calc(1120 / 736);
   }
 }
-
 .link a {
   display: inline-block;
   padding: 1rem;
   margin: 0.5rem 0;
-  font-weight: 400;
-  color: white;
-  background-color: rgba(31, 6, 255, 68.7%);
+  font-weight: 600;
+  letter-spacing: 0.3rem;
+  color: black;
+  background-color: white;
+  border: 0.19rem solid rgba(31, 6, 255, 0.687);
   border-radius: 8px;
   box-shadow: 0 4px 4px 0 rgba(0, 0, 0, 12%);
+  &:hover {
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.34);
+  }
 }
 
+.heroTechImg {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+}
 @media screen and (width >= 768px) {
   .hero {
     flex-direction: row;
@@ -43,7 +53,11 @@
       margin-bottom: 3rem;
     }
   }
-
+  .heroTechImg {
+    display: flex;
+    justify-content: start;
+    gap: 10px;
+  }
   .figure .heroImage {
     width: min(60vh, 60vw);
   }

--- a/apps/host/src/components/modules/home/hero/hero.tsx
+++ b/apps/host/src/components/modules/home/hero/hero.tsx
@@ -1,8 +1,26 @@
 import { coverTransparent } from '@fmc/assets/images';
 import styles from './hero.module.scss';
 import { HashLink } from 'react-router-hash-link';
-
+import { jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
 function Hero() {
+  const allImg = [
+    {
+      title: 'JS',
+      imgSrc: jsImg,
+    },
+    {
+      title: 'react',
+      imgSrc: reactImg,
+    },
+    {
+      title: 'vue',
+      imgSrc: vueImg,
+    },
+    {
+      title: 'angular',
+      imgSrc: angularImg,
+    },
+  ];
   return (
     <main className={styles.hero}>
       <div>
@@ -13,16 +31,19 @@ function Hero() {
         <p>by solving the collection of challenges from Frontend Mini Challenges</p>
 
         <h3 className={styles.link}>
-          <HashLink to="javascript">JS Mini Challenges</HashLink>
+          <HashLink to="javascript">Get Started</HashLink>
         </h3>
-
-        <h3 className={styles.link}>
-          <HashLink to="react">React Mini Challenges</HashLink>
-        </h3>
-
-        <h3 className={styles.link}>
-          <HashLink to="vue">Vue Mini Challenges</HashLink>
-        </h3>
+        <div className={styles.heroTechImg}>
+          {allImg.map((item) => (
+            <img
+              key={item.title}
+              src={item.imgSrc}
+              width={35}
+              height={35}
+              alt={`${item.title}-img`}
+            />
+          ))}
+        </div>
       </div>
 
       <figure className={styles.figure}>

--- a/apps/host/src/components/modules/home/hero/hero.tsx
+++ b/apps/host/src/components/modules/home/hero/hero.tsx
@@ -1,7 +1,7 @@
-import { coverTransparent } from '@fmc/assets/images';
+import { coverTransparent, jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
 import styles from './hero.module.scss';
 import { HashLink } from 'react-router-hash-link';
-import { jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
+// import { jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
 function Hero() {
   const allImg = [
     {

--- a/apps/host/src/components/modules/home/hero/hero.tsx
+++ b/apps/host/src/components/modules/home/hero/hero.tsx
@@ -1,7 +1,6 @@
 import { coverTransparent, jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
 import styles from './hero.module.scss';
 import { HashLink } from 'react-router-hash-link';
-// import { jsImg, reactImg, vueImg, angularImg } from '@fmc/assets/images';
 function Hero() {
   const allImg = [
     {


### PR DESCRIPTION
[Home] Place only one CTA on home page #411 
Title :Place only one CTA on home page

Issue No. :#411

Code Stack : 

Close #411 


# Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have created a helpful and easy to understand `README.md`
- [] I have updated the Index.html file for my contribution
<!-- [X] - put a cross/X inside [] to check the box -->

place only one CTA  (Get Started)  instead three
![Screenshot from 2024-03-03 16-12-49](https://github.com/sadanandpai/frontend-mini-challenges/assets/127741371/d9b85eea-5f31-4390-abae-5ba2bce64840)



