### PR TITLE
Fix: improve drawer menu text contrast for better mobile accessibility

### DIFF
--- a/apps/host/src/components/common/navbar/navbar.module.scss
+++ b/apps/host/src/components/common/navbar/navbar.module.scss
@@ -117,6 +117,21 @@
 .drawerContent {
   padding: 1rem;
 }
+.darkDrawer {
+  .drawerListItem a {
+    color: #ffffff;
+  }
+
+  .themeButton {
+    background-color: transparent;
+    color: #ffffff;
+    transition: all 150ms ease-in-out;
+  }
+
+  .github {
+    color: white;
+  }
+}
 
 .drawerList {
   list-style-type: none;


### PR DESCRIPTION
Title :  Improve drawer menu text contrast for better accessibility on mobile

Issue No. : #501

Code Stack : Native CSS

Closes #501

# Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have created a helpful and easy to understand `README.md`
- [] I have updated the Index.html file for my contribution


https://github.com/user-attachments/assets/dde45739-9adb-47b1-9da7-c6b220eb487b