### PR TITLE
Fix bug in the reading time of word counter app

### DIFF
--- a/apps/javascript/src/challenges/word-counter/index.js
+++ b/apps/javascript/src/challenges/word-counter/index.js
@@ -49,8 +49,8 @@ input.addEventListener('keyup', function () {
     // need to convert seconds to minutes and hours
     if (seconds > 59) {
       const minutes = Math.floor(seconds / 60);
-      seconds = seconds - minutes * 60;
-      readingTime.innerHTML = minutes + 'm ' + seconds + 's';
+      const remainingSeconds = seconds - minutes * 60;
+      readingTime.innerHTML = minutes + 'm ' + remainingSeconds + 's';
     } else {
       readingTime.innerHTML = seconds + 's';
     }


### PR DESCRIPTION
# PR summary
This PR fixes a bug where the `Reading Time` section in the word counter app fail to render correctly due to reassigning a `const` variable. In order to reproduce: Open the [word counter app](https://sadanandpai.github.io/frontend-mini-challenges/javascript/src/challenges/word-counter/) and add ≥ 275 words.

Before:
<img width="747" height="598" alt="image" src="https://github.com/user-attachments/assets/e75a7c99-1991-48d8-bd09-57f0d7882663" />


After:
<img width="773" height="748" alt="image" src="https://github.com/user-attachments/assets/ae2d91f6-eddf-4f2d-b90e-bfa93ebed63f" />


# Checklist:

- [] I have mentioned the issue number in my Pull Request.
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have created a helpful and easy to understand `README.md`
- [] I have updated the Index.html file for my contribution
<!-- [X] - put a cross/X inside [] to check the box -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected reading-time display to accurately show minutes and remaining seconds (e.g., “3m 25s”), preventing potential runtime errors in the timer display.
  * Maintains existing control flow and fallback behavior; only seconds formatting is adjusted for accuracy and stability.
  * No changes to public APIs or other challenge behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->