### PR TITLE
Fixed - #528 - Chips Input: Long unbroken text doesn't wrap or overfl…

### DIFF
--- a/apps/javascript/src/challenges/chips-input/style.css
+++ b/apps/javascript/src/challenges/chips-input/style.css
@@ -16,6 +16,8 @@ input {
   background-color: #eee;
   border: 1px solid lightgrey;
   border-radius: 1em;
+  word-break: break-word;
+  text-align: left;
 }
 
 .chip .remove {
@@ -29,5 +31,4 @@ input {
 
 .chip.finalized .remove {
   display: inherit;
-
 }


### PR DESCRIPTION
# Chips Input: Long unbroken text doesn't wrap or overflow gracefully  #528 

Title : Chips Input: Long unbroken text doesn't wrap or overflow gracefully

Issue No. : #528

Code Stack : CSS

Close 

# Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have created a helpful and easy to understand `README.md`
- [] I have updated the Index.html file for my contribution

Evidences: 
Web view - 
<img width="1590" height="908" alt="image" src="https://github.com/user-attachments/assets/6101e7f2-02a7-4358-a10a-5919476639ba" />

Ipad - 
<img width="1453" height="807" alt="image" src="https://github.com/user-attachments/assets/97889324-7c7c-477b-b339-bccc54ed8c8b" />

Mobile Devices - 
<img width="1137" height="960" alt="image" src="https://github.com/user-attachments/assets/f1fa2b44-a66a-4dda-b3a7-022e0699e1c3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Chip labels now wrap within the chip and align left for improved readability on long or multi-word content, especially on smaller screens.
- Style
  - Updated chip styling to prevent overflow/truncation and ensure consistent text alignment across chips.
- Chores
  - Removed an extraneous blank line from the stylesheet (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->