### PR TITLE
fix(vue): Add bounds checking to table colorizer functions

### DIFF
--- a/apps/vue/src/challenges/table-colorizer/index.vue
+++ b/apps/vue/src/challenges/table-colorizer/index.vue
@@ -72,14 +72,18 @@ function colorSelected() {
   const row = selectedRow.value - 1
   const col = selectedColumn.value - 1
 
-  table.value[row][col].colored = true
+  if (row >= 0 && row < table.value.length && col >= 0 && col < table.value[0].length) {
+    table.value[row][col].colored = true
+  }
 }
 
 function clearSelected() {
   const row = selectedRow.value - 1
   const col = selectedColumn.value - 1
 
-  table.value[row][col].colored = false
+  if (row >= 0 && row < table.value.length && col >= 0 && col < table.value[0].length) {
+    table.value[row][col].colored = false
+  }
 }
 
 function clearAll() {


### PR DESCRIPTION
# Description
This small PR adds bounds checking to `colorSelected()` and `clearSelected()` functions in the table colorizer Vue challenge to prevent runtime errors when users enter invalid row/column values.

Steps to reproduce:
1. Visit the [table colorizer Vue challenge](http://localhost:6014/frontend-mini-challenges/vue/#/table-colorizer)
2. Press row/column value bigger than 3 and press "color selected cell". 
3. Check DevTools.
